### PR TITLE
Add support for changes in recent http-client-0.7.* releases

### DIFF
--- a/src/WebMock.hs
+++ b/src/WebMock.hs
@@ -149,4 +149,6 @@ fromSimpleResponse Response{..} = do
     , Client.responseBody = atomicModifyIORef ref (\ c -> ("", c))
     , Client.responseCookieJar = mempty
     , Client.responseClose' = Client.ResponseClose $ return ()
+    , Client.responseOriginalRequest = error "responseOriginalRequest not supported"
+    , Client.responseEarlyHints = mempty
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,12 @@
+resolver: lts-22.38
+require-stack-version: ">=3.1"
+compiler-check: newer-minor
+packages:
+  - .
+
+extra-deps:
+  - github: assertible/http-client
+    commit: 65b5c5aa8947d2cf43f9afbef52ecca25c19cfba
+    subdirs:
+      - http-client
+      - http-conduit

--- a/vcr.cabal
+++ b/vcr.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
New fields added to construct an http-client Response have to be initialized.