### PR TITLE
withTape: Make sure that requests are replayed within the same session

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   - http-client
   - yaml
   - HUnit
+  - containers
 
 library:
   source-dirs: src

--- a/src/Imports.hs
+++ b/src/Imports.hs
@@ -13,3 +13,6 @@ import Data.IORef as Imports (IORef, newIORef, atomicWriteIORef, atomicModifyIOR
 
 atomicReadIORef :: IORef a -> IO a
 atomicReadIORef ref = atomicModifyIORef' ref (id &&& id)
+
+pass :: Applicative m => m ()
+pass = pure ()

--- a/src/WebMock.hs
+++ b/src/WebMock.hs
@@ -40,7 +40,7 @@ data Request = Request {
 , requestUrl     :: String
 , requestHeaders :: RequestHeaders
 , requestBody    :: L.ByteString
-} deriving Eq
+} deriving (Eq, Ord)
 
 instance IsString Request where
   fromString url = Request "GET" url [] ""
@@ -175,7 +175,7 @@ fromSimpleResponse request Response{..} = do
   , Client.responseHeaders = responseHeaders
   , Client.responseBody = body
   , Client.responseCookieJar = mempty
-  , Client.responseClose' = Client.ResponseClose $ return ()
+  , Client.responseClose' = Client.ResponseClose pass
   , Client.responseOriginalRequest = request { Client.requestBody = mempty }
   , Client.responseEarlyHints = mempty
   }

--- a/vcr.cabal
+++ b/vcr.cabal
@@ -29,6 +29,7 @@ library
     , base ==4.*
     , bytestring
     , case-insensitive
+    , containers
     , directory
     , filepath
     , http-client
@@ -78,6 +79,7 @@ test-suite spec
     , base ==4.*
     , bytestring
     , case-insensitive
+    , containers
     , directory
     , filepath
     , hspec


### PR DESCRIPTION
Before this change, e.g.

```haskell
withTape "tape.yaml" do
  "http://httpbin.org/status/200" `shouldReturnStatus` status200
  "http://httpbin.org/status/200" `shouldReturnStatus` status200
  "http://httpbin.org/status/200" `shouldReturnStatus` status200
```

resulted in three requests being recorded.  Now only one request is recorded and subsequently replayed.