### PR TITLE
withTape: Don't block on concurrent requests

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
   - yaml
   - HUnit
   - containers
+  - async
 
 library:
   source-dirs: src

--- a/src/Imports.hs
+++ b/src/Imports.hs
@@ -10,6 +10,8 @@ import Data.Functor as Imports
   hiding (unzip)
 #endif
 import Data.IORef as Imports (IORef, newIORef, atomicWriteIORef, atomicModifyIORef')
+import Data.ByteString as Imports (ByteString)
+import Data.ByteString.Lazy as Imports (LazyByteString)
 
 atomicReadIORef :: IORef a -> IO a
 atomicReadIORef ref = atomicModifyIORef' ref (id &&& id)

--- a/src/WebMock.hs
+++ b/src/WebMock.hs
@@ -39,7 +39,7 @@ data Request = Request {
   requestMethod  :: Method
 , requestUrl     :: String
 , requestHeaders :: RequestHeaders
-, requestBody    :: L.ByteString
+, requestBody    :: LazyByteString
 } deriving (Eq, Ord)
 
 instance IsString Request where
@@ -58,7 +58,7 @@ instance Show Request where
 data Response = Response {
   responseStatus  :: Status
 , responseHeaders :: ResponseHeaders
-, responseBody    :: L.ByteString
+, responseBody    :: LazyByteString
 } deriving (Eq, Show)
 
 instance IsString Response where

--- a/vcr.cabal
+++ b/vcr.cabal
@@ -26,6 +26,7 @@ library
   ghc-options: -Wall
   build-depends:
       HUnit
+    , async
     , base ==4.*
     , bytestring
     , case-insensitive
@@ -76,6 +77,7 @@ test-suite spec
       hspec-discover:hspec-discover
   build-depends:
       HUnit
+    , async
     , base ==4.*
     , bytestring
     , case-insensitive


### PR DESCRIPTION
This allows for a single tape to be used for an entire test suite, even when it is run in parallel, without impacting the throughput, e.g.:

```haskell
spec :: Spec
spec = parallel . aroundAll_ (withTape "tape.yaml") $ do
  ...
```