### PR TITLE
Optimize VCR for being imported qualified

### DIFF
--- a/src/VCR.hs
+++ b/src/VCR.hs
@@ -9,9 +9,9 @@
 module VCR (
   Tape(..)
 , Mode(..)
-, withTape
-, recordTape
-, playTape
+, with
+, record
+, play
 ) where
 
 import Imports
@@ -44,14 +44,14 @@ data Mode = Sequential | AnyOrder
 instance IsString Tape where
   fromString file = Tape file AnyOrder redactAuthorization
 
-withTape :: HasCallStack => Tape -> IO a -> IO a
-withTape = runTape ReadWriteMode
+with :: HasCallStack => Tape -> IO a -> IO a
+with = runTape ReadWriteMode
 
-recordTape :: Tape -> IO a -> IO a
-recordTape = runTape WriteMode
+record :: Tape -> IO a -> IO a
+record = runTape WriteMode
 
-playTape :: HasCallStack => Tape -> IO a -> IO a
-playTape = runTape ReadMode
+play :: HasCallStack => Tape -> IO a -> IO a
+play = runTape ReadMode
 
 data OpenTape mode = OpenTape {
   file :: FilePath

--- a/test/VCRSpec.hs
+++ b/test/VCRSpec.hs
@@ -67,13 +67,13 @@ respondWith responseStatus _ = return $ "" { responseStatus }
 
 spec :: Spec
 spec = around_ inTempDirectory do
-  describe "withTape" do
+  describe "with" do
     context "when mode is AnyOrder" do
       let tape = "tape.yaml"
 
       it "records requests in the order they were made" do
         mockRequestChain [respondWith status200, respondWith status202, respondWith status201] do
-          withTape tape do
+          VCR.with tape do
             "http://httpbin.org/status/200" `shouldReturnStatus` status200
             "http://httpbin.org/status/202" `shouldReturnStatus` status202
             "http://httpbin.org/status/201" `shouldReturnStatus` status201
@@ -86,7 +86,7 @@ spec = around_ inTempDirectory do
       context "with repeated requests to a resource" do
         it "records the first request, replays subsequent requests" do
           mockRequestChain [\ _ -> return ""] do
-            withTape tape do
+            VCR.with tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
@@ -95,19 +95,19 @@ spec = around_ inTempDirectory do
       context "with an existing tape" do
         it "replays existing requests from the tape" do
           mockRequest "http://httpbin.org/status/200" "" do
-            withTape tape do
+            VCR.with tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
           disableRequests do
-            withTape tape do
+            VCR.with tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
           length <$> loadTape tape.file `shouldReturn` 1
 
         it "records new requests to the tape" do
             mockRequest "http://httpbin.org/status/200" "" do
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
             mockRequest "http://httpbin.org/status/201" "" { responseStatus = status201 } do
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
             length <$> loadTape tape.file `shouldReturn` 2
 
@@ -115,7 +115,7 @@ spec = around_ inTempDirectory do
         it "records the requests concurrently, without blocking" do
           maybe (expectationFailure "<<timeout>>") return <=< timeout 100_000 . protectRequestAction $ do
             unsafeMockRequest (\ _ -> threadDelay 10_000 >> return "")
-            withTape tape do
+            VCR.with tape do
               forConcurrently_ [200 .. 299 :: Int] $ \ status -> do
                 "http://httpbin.org/status/" <> show status `shouldReturnBody` ""
           length <$> loadTape tape.file `shouldReturn` 100
@@ -123,14 +123,14 @@ spec = around_ inTempDirectory do
       context "on exception" do
         it "writes the tape to disk" do
           mockRequest "http://httpbin.org/status/500" "" { responseStatus = status500 } do
-            withTape tape (makeRequest "http://httpbin.org/status/500" [])
+            VCR.with tape (makeRequest "http://httpbin.org/status/500" [])
               `shouldThrow` httpException
           length <$> loadTape tape.file `shouldReturn` 1
 
       context "with an Authorization header" do
         it "redacts the Authorization header" do
           mockRequest authRequest "" do
-            withTape tape makeAuthRequest
+            VCR.with tape makeAuthRequest
           loadTape tape.file `shouldReturn` [(redactedAuthRequest, "")]
 
     context "when mode is Sequential" do
@@ -139,7 +139,7 @@ spec = around_ inTempDirectory do
       context "with repeated requests to a resource" do
         it "records all interactions" do
           mockRequest "http://httpbin.org/status/200" "" do
-            withTape tape do
+            VCR.with tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
@@ -148,12 +148,12 @@ spec = around_ inTempDirectory do
       context "with an existing tape" do
         it "replays request in order" do
           mockRequestChain [respondWith status200, respondWith status202, respondWith status201] do
-            withTape tape do
+            VCR.with tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/202" `shouldReturnStatus` status202
               "http://httpbin.org/status/201" `shouldReturnStatus` status201
           disableRequests $ do
-            withTape tape do
+            VCR.with tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/202" `shouldReturnStatus` status202
               "http://httpbin.org/status/201" `shouldReturnStatus` status201
@@ -166,12 +166,12 @@ spec = around_ inTempDirectory do
         context "with an out of order request" do
           it "fails" do
             mockRequestChain [respondWith status200, respondWith status201, respondWith status202] do
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
                 "http://httpbin.org/status/202" `shouldReturnStatus` status202
             disableRequests $ do
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
                 "http://httpbin.org/status/202" `shouldReturnStatus` status200
               `shouldThrow`
@@ -182,12 +182,12 @@ spec = around_ inTempDirectory do
         context "with a missing request" do
           it "fails" do
             mockRequestChain [respondWith status200, respondWith status201, respondWith status202] do
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
                 "http://httpbin.org/status/202" `shouldReturnStatus` status202
             disableRequests $ do
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
               `shouldThrow` hUnitFailure (Reason "Expected 3 requests, but only received 2!")
@@ -195,10 +195,10 @@ spec = around_ inTempDirectory do
         context "with additional requests" do
           it "records additional requests" do
             mockRequestChain [respondWith status200, respondWith status201, respondWith status202] do
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
-              withTape tape do
+              VCR.with tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
                 "http://httpbin.org/status/202" `shouldReturnStatus` status202
@@ -211,24 +211,24 @@ spec = around_ inTempDirectory do
       context "on exception" do
         it "writes the tape to disk" do
           mockRequest "http://httpbin.org/status/500" "" { responseStatus = status500 } do
-            withTape tape (makeRequest "http://httpbin.org/status/500" [])
+            VCR.with tape (makeRequest "http://httpbin.org/status/500" [])
               `shouldThrow` httpException
           length <$> loadTape tape.file `shouldReturn` 1
 
       context "with an Authorization header" do
         it "redacts the Authorization header" do
           mockRequest authRequest "" do
-            withTape tape makeAuthRequest
+            VCR.with tape makeAuthRequest
           loadTape tape.file `shouldReturn` [(redactedAuthRequest, "")]
 
-  describe "recordTape" do
+  describe "record" do
     context "when mode is AnyOrder" do
       let tape = "tape.yaml"
 
       context "with repeated requests to a resource" do
         it "records only the last interaction" do
           mockRequestChain [\ _ -> return "foo", \ _ -> return "bar", \ _ -> return "baz"] do
-            recordTape tape do
+            VCR.record tape do
               "http://httpbin.org/status/200" `shouldReturnBody` "foo"
               "http://httpbin.org/status/200" `shouldReturnBody` "bar"
               "http://httpbin.org/status/200" `shouldReturnBody` "baz"
@@ -237,22 +237,22 @@ spec = around_ inTempDirectory do
       context "with an existing tape" do
         it "records new requests to the tape" do
             mockRequest "http://httpbin.org/status/200" "" do
-              recordTape tape do
+              VCR.record tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
             mockRequest "http://httpbin.org/status/201" "" { responseStatus = status201 } do
-              recordTape tape do
+              VCR.record tape do
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
             length <$> loadTape tape.file `shouldReturn` 2
 
         it "updates existing requests, keeping the original order" do
           mockRequestChain (replicate 3 $ \ _ -> return "") do
-            recordTape tape do
+            VCR.record tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/202" `shouldReturnStatus` status200
               "http://httpbin.org/status/201" `shouldReturnStatus` status200
 
           mockRequestChain [\ _ -> return "foo"] do
-            recordTape tape do
+            VCR.record tape do
               "http://httpbin.org/status/202" `shouldReturnStatus` status200
 
           loadTape tape.file `shouldReturn` [
@@ -267,7 +267,7 @@ spec = around_ inTempDirectory do
       context "with repeated requests to a resource" do
         it "records all interactions" do
           mockRequest "http://httpbin.org/status/200" "" do
-            withTape tape do
+            VCR.with tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
@@ -276,37 +276,37 @@ spec = around_ inTempDirectory do
       context "with an existing tape" do
         it "overwrites the existing tape" do
             mockRequest "http://httpbin.org/status/200" "" do
-              recordTape tape do
+              VCR.record tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
               loadTape tape.file `shouldReturn` [
                   ("http://httpbin.org/status/200", "")
                 ]
             mockRequest "http://httpbin.org/status/201" "" { responseStatus = status201 } do
-              recordTape tape do
+              VCR.record tape do
                 "http://httpbin.org/status/201" `shouldReturnStatus` status201
               loadTape tape.file `shouldReturn` [
                   ("http://httpbin.org/status/201", "" { responseStatus = status201 })
                 ]
 
-  describe "playTape" do
+  describe "play" do
     context "when mode is AnyOrder" do
       let tape = "tape.yaml"
 
       it "replays existing requests from the tape" do
         mockRequest "http://httpbin.org/status/200" "" do
-          recordTape tape do
+          VCR.record tape do
             "http://httpbin.org/status/200" `shouldReturnStatus` status200
         disableRequests do
-          playTape tape do
+          VCR.play tape do
             "http://httpbin.org/status/200" `shouldReturnStatus` status200
         length <$> loadTape tape.file `shouldReturn` 1
 
       it "fails on new requests" do
           mockRequest "http://httpbin.org/status/200" "" do
-            recordTape tape do
+            VCR.record tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
           mockRequest "http://httpbin.org/status/201" "" { responseStatus = status201 } do
-            playTape tape do
+            VCR.play tape do
               "http://httpbin.org/status/201" `shouldReturnStatus` status201
             `shouldThrow` unexpectedRequest "http://httpbin.org/status/201"
 
@@ -315,12 +315,12 @@ spec = around_ inTempDirectory do
 
       it "replays request in order" do
         mockRequestChain [respondWith status200, respondWith status202, respondWith status201] do
-          recordTape tape do
+          VCR.record tape do
             "http://httpbin.org/status/200" `shouldReturnStatus` status200
             "http://httpbin.org/status/202" `shouldReturnStatus` status202
             "http://httpbin.org/status/201" `shouldReturnStatus` status201
         disableRequests $ do
-          playTape tape do
+          VCR.play tape do
             "http://httpbin.org/status/200" `shouldReturnStatus` status200
             "http://httpbin.org/status/202" `shouldReturnStatus` status202
             "http://httpbin.org/status/201" `shouldReturnStatus` status201
@@ -328,19 +328,19 @@ spec = around_ inTempDirectory do
       context "when not all requests are used" do
           it "fails" do
             mockRequest "http://httpbin.org/status/200" "" do
-              recordTape tape do
+              VCR.record tape do
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
                 "http://httpbin.org/status/200" `shouldReturnStatus` status200
-            playTape tape do "http://httpbin.org/status/200" `shouldReturnStatus` status200
+            VCR.play tape do "http://httpbin.org/status/200" `shouldReturnStatus` status200
               `shouldThrow` hUnitFailure (Reason "Expected 2 requests, but only received 1!")
 
       context "with additional requests" do
         it "fails" do
           mockRequest "http://httpbin.org/status/200" "" do
-            recordTape tape do
+            VCR.record tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
           mockRequestChain [\ _ -> return ""] do
-            playTape tape do
+            VCR.play tape do
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
               "http://httpbin.org/status/200" `shouldReturnStatus` status200
             `shouldThrow` unexpectedRequest "http://httpbin.org/status/200"


### PR DESCRIPTION
Rename:
- `withTape` -> `with`
- `recordTape` -> `record`
- `playTape` -> `play`